### PR TITLE
feat: move utils and client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const resolvePath = (p: string) => (path.isAbsolute(p) ? p : path.resolve(cwd, p
 const serializeDecode = (serializer: TSerializer) => async (
 	decoded: Right<ValidationError[], TSwaggerObject>,
 	out: string,
-): Promise<TFSEntity> => serializer(path.basename(out), decoded.value);
+): Promise<TFSEntity> => serializer(path.basename(out), decoded.value, out);
 
 const getPrettierConfig = async (pathToPrettierConfig?: string): Promise<Option<prettier.Options>> =>
 	fromNullable(

--- a/src/language/typescript.ts
+++ b/src/language/typescript.ts
@@ -143,13 +143,14 @@ const getRelativeRefPath = (cwd: string, refBlockName: string, refFileName: stri
 	`${getRelativeRoot(cwd)}/${refBlockName}/${refFileName}`;
 const getRelativeOutRefPath = (cwd: string, blockName: string, outFileName: string, refFileName: string): string =>
 	`${getRelativeRoot(cwd)}/../${outFileName}/${blockName}/${refFileName}`;
-const getRelativeClientPath = (cwd: string): string => `${getRelativeRoot(cwd)}/${CLIENT_DIRECTORY}/${CLIENT_FILENAME}`;
-const getRelativeUtilsPath = (cwd: string): string => `${getRelativeRoot(cwd)}/${UTILS_DIRECTORY}/${UTILS_FILENAME}`;
+const getRelativeClientPath = (cwd: string): string =>
+	`../${getRelativeRoot(cwd)}/${CLIENT_DIRECTORY}/${CLIENT_FILENAME}`;
+const getRelativeUtilsPath = (cwd: string): string => `../${getRelativeRoot(cwd)}/${UTILS_DIRECTORY}/${UTILS_FILENAME}`;
 
 export const serialize: TSerializer = (name: string, swaggerObject: TSwaggerObject): TDirectory =>
 	directory(name, [
-		directory(CLIENT_DIRECTORY, [file(`${CLIENT_FILENAME}.ts`, client)]),
-		directory(UTILS_DIRECTORY, [file(`${UTILS_FILENAME}.ts`, utils)]),
+		directory(`../${CLIENT_DIRECTORY}`, [file(`${CLIENT_FILENAME}.ts`, client)]),
+		directory(`../${UTILS_DIRECTORY}`, [file(`${UTILS_FILENAME}.ts`, utils)]),
 		...catOptions([swaggerObject.definitions.map(serializeDefinitions)]),
 		serializePaths(swaggerObject.paths, swaggerObject.parameters),
 	]);

--- a/src/language/typescript.ts
+++ b/src/language/typescript.ts
@@ -147,10 +147,10 @@ const getRelativeClientPath = (cwd: string): string =>
 	`../${getRelativeRoot(cwd)}/${CLIENT_DIRECTORY}/${CLIENT_FILENAME}`;
 const getRelativeUtilsPath = (cwd: string): string => `../${getRelativeRoot(cwd)}/${UTILS_DIRECTORY}/${UTILS_FILENAME}`;
 
-export const serialize: TSerializer = (name: string, swaggerObject: TSwaggerObject): TDirectory =>
+export const serialize: TSerializer = (name: string, swaggerObject: TSwaggerObject, out: string): TDirectory =>
 	directory(name, [
-		directory(`../${CLIENT_DIRECTORY}`, [file(`${CLIENT_FILENAME}.ts`, client)]),
-		directory(`../${UTILS_DIRECTORY}`, [file(`${UTILS_FILENAME}.ts`, utils)]),
+		directory(out, [file(`${CLIENT_FILENAME}.ts`, client)]),
+		directory(out, [file(`${UTILS_FILENAME}.ts`, utils)]),
 		...catOptions([swaggerObject.definitions.map(serializeDefinitions)]),
 		serializePaths(swaggerObject.paths, swaggerObject.parameters),
 	]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ import { camelize } from '@devexperts/utils/dist/string/string';
 import { option, Option, some } from 'fp-ts/lib/Option';
 import { sequence } from 'fp-ts/lib/Traversable';
 
-export type TSerializer = (name: string, schema: TSwaggerObject) => TFSEntity;
+export type TSerializer = (name: string, schema: TSwaggerObject, out: string) => TFSEntity;
 
 export const getOperationsFromPath = (path: TPathItemObject): TDictionary<TOperationObject> => {
 	const result: TDictionary<TOperationObject> = {};


### PR DESCRIPTION
utils and client was generated 1 instance for each spec. now there's only one instance for all at the same level as specs